### PR TITLE
update tsconfig.json file to include target option

### DIFF
--- a/features/step_definitions/tsconfig.json
+++ b/features/step_definitions/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "experimentalDecorators": true,
-        "module": "commonjs"
+        "module": "commonjs",
+        "target": "es5"
     }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs"
+        "module": "commonjs",
+        "target": "es5"
     }
 }


### PR DESCRIPTION
This PR will fix the compiler issues of using given, when, and then as method decorators.

It appears that the TypeScript compiler requires the `target` option when applying method decorators.
